### PR TITLE
Update api.md setChannel incomplete doc

### DIFF
--- a/plugin/api.md
+++ b/plugin/api.md
@@ -138,13 +138,17 @@ Set delay to skip updates in the next time the app goes into the background
 | ------------- | --------------------- |
 | **`options`** | `{ delay: boolean; }` |
 
-### setChannel()
+### setChannel(...)
 
 ```typescript
-setChannel() => Promise<channelRes>
+setChannel(options: { channel: string; }) => Promise<channelRes>
 ```
 
 Set Channel for this device
+
+| Param         | Type                  |
+| ------------- | --------------------- |
+| **`options`** | `{ channel: string; }` |
 
 **Returns:** `Promise<channelRes>`
 


### PR DESCRIPTION
According to [this blog post ](https://capgo.app/blog/how-to-send-specific-version-to-users/)`setChannel` method should be called with `options` object with `channel` property